### PR TITLE
Don't run diff when changing tab focus

### DIFF
--- a/vcs_gutter_events.py
+++ b/vcs_gutter_events.py
@@ -36,6 +36,9 @@ class VcsGutterEvents(sublime_plugin.EventListener):
             ViewCollection.add(view)
 
     def on_activated(self, view):
+        if not _live_mode:
+            return None
+
         ViewCollection.add(view)
 
     def load_settings(self):


### PR DESCRIPTION
Don't run diff when changing tab focus if live mode is disabled.

Solves https://github.com/bradsokol/VcsGutter/issues/12
