### PR TITLE
Fix reading output from hg

### DIFF
--- a/gutter_handlers.py
+++ b/gutter_handlers.py
@@ -157,6 +157,7 @@ class VcsGutterHandler(object):
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         try:
             proc = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
                                     startupinfo=startupinfo)
         except OSError as e:
             print('Vcs Gutter: Failed to run command %r: %r' % (args[0], e))


### PR DESCRIPTION
On my computer (Windows 7, Sublime Text 3047) when opening file in mercurial repository all lines where marked as 'added'. It turns out that when running hg its `proc.stdout.read()`. This commit fixes it by redirecting `stderr` too.
