### PR TITLE
Port Next/Previous Change key commands from GitGutter

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,4 @@
+[
+    { "keys": ["ctrl+shift+alt+j"], "command": "vcs_gutter_next_change" },
+    { "keys": ["ctrl+shift+alt+k"], "command": "vcs_gutter_prev_change" }
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,4 @@
+[
+    { "keys": ["super+shift+option+j"], "command": "vcs_gutter_next_change" },
+    { "keys": ["super+shift+option+k"], "command": "vcs_gutter_prev_change" }
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,4 @@
+[
+    { "keys": ["ctrl+shift+alt+j"], "command": "vcs_gutter_next_change" },
+    { "keys": ["ctrl+shift+alt+k"], "command": "vcs_gutter_prev_change" }
+]

--- a/vcs_gutter_change.py
+++ b/vcs_gutter_change.py
@@ -1,0 +1,42 @@
+import sublime_plugin
+try:
+    from VcsGutter.view_collection import ViewCollection
+except ImportError:
+    from view_collection import ViewCollection
+
+class VcsGutterBaseChangeCommand(sublime_plugin.WindowCommand):
+    def lines_to_blocks(self, lines):
+        blocks = []
+        last_line = -2
+        for line in lines:
+            if line > last_line+1:
+                blocks.append(line)
+            last_line = line
+        return blocks
+
+    def run(self):
+        view = self.window.active_view()
+
+        inserted, modified, deleted = ViewCollection.diff(view)
+        inserted = self.lines_to_blocks(inserted)
+        modified = self.lines_to_blocks(modified)
+        all_changes = sorted(inserted + modified + deleted)
+        if all_changes:
+            row, col = view.rowcol(view.sel()[0].begin())
+
+            current_row = row + 1
+
+            line = self.jump(all_changes, current_row)
+
+            self.window.active_view().run_command("goto_line", {"line": line})
+
+class VcsGutterNextChangeCommand(VcsGutterBaseChangeCommand):
+    def jump(self, all_changes, current_row):
+        return next((change for change in all_changes
+                        if change > current_row), all_changes[0])
+
+
+class VcsGutterPrevChangeCommand(VcsGutterBaseChangeCommand):
+    def jump(self, all_changes, current_row):
+        return next((change for change in reversed(all_changes)
+                        if change < current_row), all_changes[-1])


### PR DESCRIPTION
GitGutter includes keyboard shortcuts to jump between changed parts of a file. This commit resolves #5 by porting that functionality from GitGutter's [git_gutter_change.py](https://github.com/jisaacks/GitGutter/blob/master/git_gutter_change.py) file, and also copies over the associated keymap files.
