### PR TITLE
Show VcsGutter in Minimap

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ VCS Gutter is a "friendly fork" that builds on the original work by
 
 ### Installation
 
-You can install via [Sublime Package Control](http://wbond.net/sublime_packages/package_control)  
+You can install via [Sublime Package Control](http://wbond.net/sublime_packages/package_control)
 Or you can clone this repo into your *Sublime Text 2/Packages*
 
 *Mac OS X*
@@ -55,6 +55,9 @@ Default settings should not be modified, as they are overwritten when VCS Gutter
 
 #### Live Mode
 By default, VCS Gutter detects changes every time the file is modified. If you experience performance issues you can set it to only run on save by setting `live_mode` to `false`.
+
+#### Show in Minimap
+By default, this is turned off. When the parameter ```shown_in_minimap``` is set to true, then the gutter icons are also shown on the minimap.
 
 #### Non Blocking Mode
 By default, VcsGutter runs in the same thread which can block if it starts to perform slowly. Usually this isn't a problem but depending on the size of your file or repo it can be. If you set `non_blocking` to `true` then VcsGutter will run in a seperate thread and will not block. This does cause a slight delay between when you make a modification and when the icons update in the gutter. This is a ***Sublime Text 3 only feature***. Sublime Text 2 users can turn off live mode if performance is an issue.

--- a/VcsGutter.sublime-settings
+++ b/VcsGutter.sublime-settings
@@ -3,11 +3,14 @@
     // Set to false to disable evaluation after each input.
     // Restart Sublime Text to activate this change.
     "live_mode": true,
-  
+
     // When set to true VcsGutter runs asynchronously in a seperate thread
     // This may cause a small delay between a modification and the icon change
     // but can increase performance greatly if needed. Sublime Text 3 only.
     "non_blocking": false,
+
+    // Set this to true to show the gutter colors also in the minimap
+    "show_in_minimap": false,
 
     // Paths to VCS commands. Modify if the executable is not in your path.
     //

--- a/vcs_gutter.py
+++ b/vcs_gutter.py
@@ -5,6 +5,9 @@ try:
 except ValueError:
     from view_collection import ViewCollection
 
+ST3 = int(sublime.version()) >= 3000
+
+_show_in_minimap = False
 
 def plugin_loaded():
     """
@@ -19,6 +22,9 @@ def plugin_loaded():
     if not exists(icon_path):
         makedirs(icon_path)
 
+    settings = sublime.load_settings('VcsGutter.sublime-settings')
+    global _show_in_minimap
+    _show_in_minimap = settings.get('show_in_miminap', False)
 
 class VcsGutterCommand(sublime_plugin.WindowCommand):
     region_names = ['deleted_top', 'deleted_bottom',
@@ -44,7 +50,7 @@ class VcsGutterCommand(sublime_plugin.WindowCommand):
         regions = []
         for line in lines:
             position = self.view.text_point(line - 1, 0)
-            region = sublime.Region(position, position)
+            region = sublime.Region(position, position+1)
             regions.append(region)
         return regions
 
@@ -79,4 +85,8 @@ class VcsGutterCommand(sublime_plugin.WindowCommand):
             event_scope = 'deleted'
         scope = 'markup.%s.vcs_gutter' % event_scope
         icon = self.icon_path(event)
-        self.view.add_regions('vcs_gutter_%s' % event, regions, scope, icon)
+        if ST3 and _show_in_minimap:
+            flags = sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE
+        else:
+            flags = sublime.HIDDEN
+        self.view.add_regions('vcs_gutter_%s' % event, regions, scope, icon, flags)

--- a/vcs_gutter.py
+++ b/vcs_gutter.py
@@ -24,7 +24,7 @@ def plugin_loaded():
 
     settings = sublime.load_settings('VcsGutter.sublime-settings')
     global _show_in_minimap
-    _show_in_minimap = settings.get('show_in_miminap', False)
+    _show_in_minimap = settings.get('show_in_mimimap', False)
 
 class VcsGutterCommand(sublime_plugin.WindowCommand):
     region_names = ['deleted_top', 'deleted_bottom',

--- a/vcs_gutter.py
+++ b/vcs_gutter.py
@@ -24,7 +24,7 @@ def plugin_loaded():
 
     settings = sublime.load_settings('VcsGutter.sublime-settings')
     global _show_in_minimap
-    _show_in_minimap = settings.get('show_in_mimimap', False)
+    _show_in_minimap = settings.get('show_in_minimap', False)
 
 class VcsGutterCommand(sublime_plugin.WindowCommand):
     region_names = ['deleted_top', 'deleted_bottom',


### PR DESCRIPTION
Add a setting which allows to enable/disable the display of the gutter also in the minimap:
"show_in_minimap": true shows the VcsGutter. If this statement is omitted or set to false, the behaviour is as it was before.
Tested with ST3 on Win.