### PR TITLE
Include Fossil-SCM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd %USERPROFILE%\AppData\Roaming\Sublime Text 2\Packages
 git clone git://github.com/bradsokol/VcsGutter.git "VCS Gutter"
 ```
 
-VcsGutter assumes that the `git`, `hg`, `svn` and `diff` commands are availible on the command line. The installers for these tools may not add the directory containing the executables to the PATH environment variable. If not, you must add the appropriate directory to your PATH variable.
+VcsGutter assumes that the `git`, `hg`, `svn`, `fossil` and `diff` commands are availible on the command line. The installers for these tools may not add the directory containing the executables to the PATH environment variable. If not, you must add the appropriate directory to your PATH variable.
 
 For example:
 ```dos
@@ -63,14 +63,15 @@ By default, this is turned off. When the parameter ```shown_in_minimap``` is set
 By default, VcsGutter runs in the same thread which can block if it starts to perform slowly. Usually this isn't a problem but depending on the size of your file or repo it can be. If you set `non_blocking` to `true` then VcsGutter will run in a seperate thread and will not block. This does cause a slight delay between when you make a modification and when the icons update in the gutter. This is a ***Sublime Text 3 only feature***. Sublime Text 2 users can turn off live mode if performance is an issue.
 
 #### Executable Path
-If your VCS executable (git, hg, or svn) or diff utility is not in your PATH, you may need to set the `vcs_paths` setting to the location of your executables:
+If your VCS executable (git, hg, or svn, fossil) or diff utility is not in your PATH, you may need to set the `vcs_paths` setting to the location of your executables:
 ```js
 {
     "vcs_paths": {
         "diff": "diff",
         "git": "git",
         "hg": "/usr/local/bin/hg",
-        "svn": "svn"
+        "svn": "svn",
+        "fossil": "fossil"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-## VCS Gutter
+## VCS Gutter Modern
 
 **Now supporting Sublime Text 3.**
 
-VCS Gutter is a plugin for Sublime Text 2 and 3 that displays an icon in the gutter area indicating whether a line has been inserted, modified or deleted relative to the version of the file in the local source
-code repository. VCS Gutter supports Git, Mercurial and Subversion.
+VCS Gutter Modern is a plugin for Sublime Text 2 and 3 that displays an icon in the gutter area indicating whether a line has been inserted, modified or deleted relative to the version of the file in the local source
+code repository. VCS Gutter supports Fossil, Git, Mercurial and Subversion.
 
-VCS Gutter is a "friendly fork" that builds on the original work by
-[jisaacks](https://github.com/jisaacks) on [GitGutter](https://github.com/jisaacks/GitGutter).
+Note: this is a fork of the unmaintained version of VcsGutter from https://github.com/bradsokol/VcsGutter / It adds support for Fossil, and any contribution is welcome.
+
+VCS Gutter was originally a "friendly fork" that builds on the original work by [jisaacks](https://github.com/jisaacks) on [GitGutter](https://github.com/jisaacks/GitGutter).
 
 ### Screenshot:
 
@@ -20,20 +21,20 @@ Or you can clone this repo into your *Sublime Text 2/Packages*
 *Mac OS X*
 ```shell
 cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/
-git clone git://github.com/bradsokol/VcsGutter.git "VCS Gutter"
+git clone https://github.com/bohwaz/VcsGutter.git "VCS Gutter"
 ```
 
 *Ubuntu*
 ```shell
 cd ~/.config/sublime-text-2/Packages
-git clone git://github.com/bradsokol/VcsGutter.git "VCS Gutter"
+git clone https://github.com/bohwaz/VcsGutter.git "VCS Gutter"
 ```
 
 *Windows*
 
 ```shell
 cd %USERPROFILE%\AppData\Roaming\Sublime Text 2\Packages
-git clone git://github.com/bradsokol/VcsGutter.git "VCS Gutter"
+git clone https://github.com/bohwaz/VcsGutter.git "VCS Gutter"
 ```
 
 VcsGutter assumes that the `git`, `hg`, `svn`, `fossil` and `diff` commands are availible on the command line. The installers for these tools may not add the directory containing the executables to the PATH environment variable. If not, you must add the appropriate directory to your PATH variable.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@
 **Now supporting Sublime Text 3.**
 
 VCS Gutter Modern is a plugin for Sublime Text 2 and 3 that displays an icon in the gutter area indicating whether a line has been inserted, modified or deleted relative to the version of the file in the local source
-code repository. VCS Gutter supports Fossil, Git, Mercurial and Subversion.
+code repository. VCS Gutter supports:
+
+* Fossil
+* Git
+* Mercurial
+* Subversion
+
+Any pull request for a different VCS is more than welcome!
 
 Note: this is a fork of the unmaintained version of VcsGutter from https://github.com/bradsokol/VcsGutter / It adds support for Fossil, and any contribution is welcome.
 

--- a/gutter_handlers.py
+++ b/gutter_handlers.py
@@ -84,6 +84,8 @@ class VcsGutterHandler(object):
             open(self.vcs_temp_file.name, 'w').close()
             args = self.get_diff_args()
             try:
+                # Necessary for Fossil (needs to be in checkout)
+                os.chdir(self.vcs_tree)
                 contents = self.run_command(args)
                 contents = contents.replace(b'\r\n', b'\n')
                 contents = contents.replace(b'\r', b'\n')
@@ -178,7 +180,7 @@ class GitGutterHandler(VcsGutterHandler):
     def get_diff_args(self):
         args = [
             self.exc_path,
-            '--git-dir=' + self.vcs_dir,
+            '--git-dir=' + self.vcs_dir[0],
             '--work-tree=' + self.vcs_tree,
             'show',
             'HEAD:' + self.vcs_path,
@@ -210,5 +212,17 @@ class SvnGutterHandler(VcsGutterHandler):
             self.exc_path,
             'cat',
             os.path.join(self.vcs_tree, self.vcs_path),
+        ]
+        return args
+
+class FossilGutterHandler(VcsGutterHandler):
+    def get_vcs_helper(self):
+        return vcs_helpers.FossilHelper()
+
+    def get_diff_args(self):
+        args = [
+            self.exc_path,
+            'cat',
+            self.vcs_path,
         ]
         return args

--- a/view_collection.py
+++ b/view_collection.py
@@ -4,9 +4,9 @@ import time
 import sublime
 
 try:
-    from .vcs_helpers import GitHelper, HgHelper, SvnHelper
+    from .vcs_helpers import GitHelper, HgHelper, SvnHelper, FossilHelper
 except ValueError:
-    from vcs_helpers import GitHelper, HgHelper, SvnHelper
+    from vcs_helpers import GitHelper, HgHelper, SvnHelper, FossilHelper
 
 
 class ViewCollection:
@@ -18,15 +18,16 @@ class ViewCollection:
     @staticmethod
     def add(view):
         try:
-            from .gutter_handlers import GitGutterHandler, HgGutterHandler, SvnGutterHandler
+            from .gutter_handlers import GitGutterHandler, HgGutterHandler, SvnGutterHandler, FossilGutterHandler
         except ValueError:
-            from gutter_handlers import GitGutterHandler, HgGutterHandler, SvnGutterHandler
+            from gutter_handlers import GitGutterHandler, HgGutterHandler, SvnGutterHandler, FossilGutterHandler
 
         settings = sublime.load_settings('VcsGutter.sublime-settings')
         vcs_paths = settings.get('vcs_paths', {
             'git': 'git',
             'hg': 'hg',
-            'svn': 'svn'
+            'svn': 'svn',
+            'fossil': 'fossil'
         })
 
         key = None
@@ -39,6 +40,9 @@ class ViewCollection:
         elif SvnHelper.is_svn_repository(view):
             key = 'svn'
             klass = SvnGutterHandler
+        elif FossilHelper.is_fossil_repository(view):
+            key = 'fossil'
+            klass = FossilGutterHandler
 
         handler = None
         if key is not None:


### PR DESCRIPTION
This patch brings Fossil-SCM support.

Some of the meta_data_directory code has been changed as Fossil checkout metadata file can be named either _FOSSIL_ or .fslckout.
